### PR TITLE
Persistent memory check value verification, defaulting when fails. (#…

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -245,13 +245,9 @@ SetUIView::SetUIView(NavigationView& nav) {
 	checkbox_showclock.set_value(!persistent_memory::hide_clock());
 	checkbox_guireturnflag.set_value(persistent_memory::show_gui_return_icon());
 	
-	uint32_t backlight_timer = persistent_memory::config_backlight_timer();
-	if (backlight_timer) {
-		checkbox_bloff.set_value(true);
-		options_bloff.set_by_value(backlight_timer);
-	} else {
-		options_bloff.set_selected_index(0);
-	}
+	const auto backlight_config = persistent_memory::config_backlight_timer();
+	checkbox_bloff.set_value(backlight_config.timeout_enabled());
+	options_bloff.set_by_value(backlight_config.timeout_enum());
 
 	if (persistent_memory::clock_with_date()) {
 		options_clockformat.set_selected_index(1);
@@ -261,11 +257,11 @@ SetUIView::SetUIView(NavigationView& nav) {
 
 
 	button_save.on_select = [&nav, this](Button&) {
-		if (checkbox_bloff.value())
-			persistent_memory::set_config_backlight_timer(options_bloff.selected_index() + 1);
-		else
-			persistent_memory::set_config_backlight_timer(0);
-		
+		persistent_memory::set_config_backlight_timer({
+			(persistent_memory::backlight_timeout_t)options_bloff.selected_index_value(),
+			checkbox_bloff.value()
+		});
+				
 		if (checkbox_showclock.value()){
 		    if (options_clockformat.selected_index() == 1)
 			    persistent_memory::set_clock_with_date(true);    

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -27,6 +27,7 @@
 #include "ui_menu.hpp"
 #include "ui_navigation.hpp"
 #include "ff.h"
+#include "portapack_persistent_memory.hpp"
 
 #include <cstdint>
 
@@ -210,6 +211,8 @@ private:
 	SetFrequencyCorrectionModel form_collect();
 };
 
+using portapack::persistent_memory::backlight_timeout_t;
+
 class SetUIView : public View {
 public:
 	SetUIView(NavigationView& nav);
@@ -241,13 +244,14 @@ private:
 		{ 52, 7 * 16 + 8 },
 		20,
 		{
-			{ "5 seconds", 5 },
-			{ "15 seconds", 15 },
-			{ "30 seconds", 30 },
-			{ "1 minute", 60 },
-			{ "3 minutes", 180 },
-			{ "5 minutes", 300 },
-			{ "10 minutes", 600 }
+			{ "5 seconds",  backlight_timeout_t::Timeout5Sec    },
+			{ "15 seconds", backlight_timeout_t::Timeout15Sec   },
+			{ "30 seconds", backlight_timeout_t::Timeout30Sec   },
+			{ "1 minute",   backlight_timeout_t::Timeout60Sec   },
+			{ "3 minutes",  backlight_timeout_t::Timeout180Sec  },
+			{ "5 minutes",  backlight_timeout_t::Timeout300Sec  },
+			{ "10 minutes", backlight_timeout_t::Timeout600Sec  },
+			{ "1 hour",     backlight_timeout_t::Timeout3600Sec },
 		}
 	};
 	

--- a/firmware/application/apps/ui_touch_calibration.cpp
+++ b/firmware/application/apps/ui_touch_calibration.cpp
@@ -31,7 +31,7 @@ namespace ui {
 TouchCalibrationView::TouchCalibrationView(
 	NavigationView& nav
 ) : nav { nav },
-	calibration { touch::default_calibration() }
+	calibration { touch::Calibration() }
 {
 	add_children({
 		&image_calibrate_0,

--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -226,15 +226,17 @@ void EventDispatcher::handle_rtc_tick() {
 
 	portapack::temperature_logger.second_tick();
 	
-	uint32_t backlight_timer = portapack::persistent_memory::config_backlight_timer();
-	if (backlight_timer) {
-		if (portapack::bl_tick_counter == backlight_timer)
+	const auto backlight_timer = portapack::persistent_memory::config_backlight_timer();
+	if (backlight_timer.timeout_enabled()) {
+		if (portapack::bl_tick_counter == backlight_timer.timeout_seconds())
 			set_display_sleep(true);
 		else
 			portapack::bl_tick_counter++;
 	}
 
 	rtc_time::on_tick_second();
+
+	portapack::persistent_memory::cache::persist();
 }
 
 ui::Widget* EventDispatcher::touch_widget(ui::Widget* const w, ui::TouchEvent event) {

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -457,6 +457,9 @@ bool init() {
 	i2c0.start(i2c_config_fast_clock);
 	chThdSleepMilliseconds(10);
 
+	/* Cache some configuration data from persistent memory. */
+	persistent_memory::cache::init();
+
 	touch::adc::init();
 	controls_init();
 	chThdSleepMilliseconds(10);

--- a/firmware/application/serializer.hpp
+++ b/firmware/application/serializer.hpp
@@ -45,6 +45,14 @@ struct serial_format_t {
 	parity_enum parity;
 	uint8_t stop_bits;
 	order_enum bit_order;
+
+	constexpr serial_format_t() :
+		data_bits(7),
+		parity(parity_enum::EVEN),
+		stop_bits(1),
+		bit_order(order_enum::LSB_FIRST)
+	{
+	}
 };
 
 size_t symbol_count(const serial_format_t& serial_format);

--- a/firmware/application/touch.cpp
+++ b/firmware/application/touch.cpp
@@ -76,14 +76,6 @@ ui::Point Calibration::translate(const DigitizerPoint& p) const {
 	return { x_clipped, y_clipped };
 }
 
-const Calibration default_calibration() {
-	/* Values derived from one PortaPack H1 unit. */
-	return {
-		{ { { 256, 731 }, { 880, 432 }, { 568, 146 } } },
-		{ { {  32,  48 }, { 208, 168 }, { 120, 288 } } }
-	};
-};
-
 void Manager::feed(const Frame& frame) {
 	// touch_debounce.feed(touch_raw);
 	const auto touch_raw = frame.touch;

--- a/firmware/application/touch.hpp
+++ b/firmware/application/touch.hpp
@@ -137,6 +137,15 @@ struct Calibration {
 	{
 	}
 
+	constexpr Calibration() :
+		Calibration(
+			/* Values derived from one PortaPack H1 unit. */
+			{ { { 256, 731 }, { 880, 432 }, { 568, 146 } } },
+			{ { {  32,  48 }, { 208, 168 }, { 120, 288 } } }
+		)
+	{
+	}
+
 	ui::Point translate(const DigitizerPoint& p) const;
 
 private:
@@ -148,8 +157,6 @@ private:
 	int32_t e;
 	int32_t f;
 };
-
-const Calibration default_calibration();
 
 template<size_t N>
 class Filter {

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -25,6 +25,8 @@
 
 #include <cstdint>
 
+#include "optional.hpp"
+
 #include "rf_path.hpp"
 #include "touch.hpp"
 #include "modems.hpp"
@@ -35,6 +37,77 @@ using namespace serializer;
 
 namespace portapack {
 namespace persistent_memory {
+
+enum backlight_timeout_t {
+    Timeout5Sec    = 0,
+    Timeout15Sec   = 1,
+    Timeout30Sec   = 2,
+    Timeout60Sec   = 3,
+    Timeout180Sec  = 4,
+    Timeout300Sec  = 5,
+    Timeout600Sec  = 6,
+    Timeout3600Sec = 7,
+};
+
+struct backlight_config_t {
+public:
+    backlight_config_t() :
+        _timeout_enum(backlight_timeout_t::Timeout600Sec),
+        _timeout_enabled(false)
+    {
+    }
+
+    backlight_config_t(
+        backlight_timeout_t timeout_enum,
+        bool timeout_enabled
+    ) :
+        _timeout_enum(timeout_enum),
+        _timeout_enabled(timeout_enabled)
+    {
+    }
+
+    bool timeout_enabled() const {
+        return _timeout_enabled;
+    }
+
+    backlight_timeout_t timeout_enum() const {
+        return _timeout_enum;
+    }
+
+    uint32_t timeout_seconds() const {
+        switch(timeout_enum()) {
+            case Timeout5Sec:    return    5;
+            case Timeout15Sec:   return   15;
+            case Timeout30Sec:   return   30;
+            case Timeout60Sec:   return   60;
+            case Timeout180Sec:  return  180;
+            case Timeout300Sec:  return  300;
+            default:
+            case Timeout600Sec:  return  600;
+            case Timeout3600Sec: return 3600;
+        }
+    }
+
+private:
+    backlight_timeout_t _timeout_enum;
+    bool _timeout_enabled;
+};
+
+namespace cache {
+
+/* Set values in cache to sensible defaults. */
+void defaults();
+
+/* Load cached settings from values in persistent RAM, replacing with defaults
+ * if persistent RAM contents appear to be invalid. */
+void init();
+
+/* Calculate a check value for cached settings, and copy the check value and
+ * settings into persistent RAM. Intended to be called periodically to update
+ * persistent settings with current settings. */
+void persist();
+
+} /* namespace cache */
 
 using ppb_t = int32_t;
 
@@ -86,7 +159,7 @@ bool hide_clock();
 bool clock_with_date();
 bool config_login();
 bool config_speaker();
-uint32_t config_backlight_timer();
+backlight_config_t config_backlight_timer();
 bool disable_touchscreen();
 
 void set_gui_return_icon(bool v);
@@ -98,7 +171,7 @@ void set_clock_hidden(bool v);
 void set_clock_with_date(bool v);
 void set_config_login(bool v);
 void set_config_speaker(bool v); 
-void set_config_backlight_timer(uint32_t i);
+void set_config_backlight_timer(const backlight_config_t& new_value);
 void set_disable_touchscreen(bool v);
 
 //uint8_t ui_config_textentry();

--- a/firmware/common/utility.hpp
+++ b/firmware/common/utility.hpp
@@ -95,27 +95,27 @@ struct range_t {
 	const T minimum;
 	const T maximum;
 
-	const T& clip(const T& value) const {
+	constexpr const T& clip(const T& value) const {
 		return std::max(std::min(value, maximum), minimum);
 	}
 
-	void reset_if_outside(T& value, const T& reset_value) const {
+	constexpr void reset_if_outside(T& value, const T& reset_value) const {
 		if( (value < minimum ) ||
 			(value > maximum ) ) {
 			value = reset_value;
 		}
 	}
 
-	bool below_range(const T& value) const {
+	constexpr bool below_range(const T& value) const {
 		return value < minimum;
 	}
 
-	bool contains(const T& value) const {
+	constexpr bool contains(const T& value) const {
 		// TODO: Subtle gotcha here! Range test doesn't include maximum!
 		return (value >= minimum) && (value < maximum);
 	}
 
-	bool out_of_range(const T& value) const {
+	constexpr bool out_of_range(const T& value) const {
 		// TODO: Subtle gotcha here! Range test in contains() doesn't include maximum!
 		return !contains(value);
 	}


### PR DESCRIPTION
…662)

* Make default constructor for touch calibration

* Add persistent memory check value and access abstraction.

* Add persistent data_t default constructor with reasonable defaults.

* serial_format_t default constructor.

* Tidy up backlight timeout type.

* Add persistent data struct version/checking.

* Make range_t functions constexpr.

* Move ui_config and functions into class.

* Add backlight_config_t struct, separate enable and time settings.